### PR TITLE
Arrows now only open the selected Entity

### DIFF
--- a/ApostleEditor/imgui.ini
+++ b/ApostleEditor/imgui.ini
@@ -69,14 +69,14 @@ Collapsed=0
 DockId=0x0000000B,1
 
 [Docking][Data]
-DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=268,315 Size=1280,696 Split=X Selected=0x13926F0B
+DockSpace           ID=0x3BC79352 Window=0x4647B76E Pos=60,107 Size=1280,696 Split=X Selected=0x13926F0B
   DockNode          ID=0x00000007 Parent=0x3BC79352 SizeRef=353,701 Selected=0xE87781F4
   DockNode          ID=0x00000008 Parent=0x3BC79352 SizeRef=925,701 Split=X
     DockNode        ID=0x00000001 Parent=0x00000008 SizeRef=931,701 Split=X Selected=0x06DE3C0F
       DockNode      ID=0x00000005 Parent=0x00000001 SizeRef=2052,948 CentralNode=1 Selected=0x13926F0B
       DockNode      ID=0x00000006 Parent=0x00000001 SizeRef=506,948 Split=Y Selected=0xE7039252
         DockNode    ID=0x00000009 Parent=0x00000006 SizeRef=506,902 Split=Y Selected=0x2E9237F7
-          DockNode  ID=0x0000000B Parent=0x00000009 SizeRef=506,247 Selected=0x2E4EBCAA
+          DockNode  ID=0x0000000B Parent=0x00000009 SizeRef=506,247 Selected=0x2E9237F7
           DockNode  ID=0x0000000C Parent=0x00000009 SizeRef=506,447 Selected=0xFC3EA205
         DockNode    ID=0x0000000A Parent=0x00000006 SizeRef=506,441 Split=Y Selected=0xE7039252
           DockNode  ID=0x00000003 Parent=0x0000000A SizeRef=506,704 Selected=0xE7039252

--- a/ApostleEditor/src/Panels/SceneHierarchyPanel.cpp
+++ b/ApostleEditor/src/Panels/SceneHierarchyPanel.cpp
@@ -95,7 +95,7 @@ namespace Apostle {
 		
 		ImGuiTreeNodeFlags flags = ((m_SelectionContext == entity) ? ImGuiTreeNodeFlags_Selected : 0) | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
 		flags |= ImGuiTreeNodeFlags_SpanAvailWidth;
-		bool opened = ImGui::TreeNodeEx((void*)(uint64_t)(uint32_t)entity, flags, tag.c_str());
+		bool opened = ImGui::TreeNodeEx((void*)(uint64_t)(uint32_t)entity.GetUUID(), flags, tag.c_str());
 		if (ImGui::IsItemClicked())
 		{
 			m_SelectionContext = entity;


### PR DESCRIPTION
Switched from using the Entity itself, to using the UUID of the Entity to create the tree nodes in the Scene Hierarchy Panel.